### PR TITLE
[build] fix up ESM module structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,5 +7,5 @@ ported from https://github.com/padenot/ringbuf.js/blob/main/js/ringbuf.js
 # Install
 
 ```
-yarn add @thirdroom/ringbuffer
+yarn add @joelrbrandt/ringbuffer
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thirdroom/ringbuffer",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "description": "thread safe data structures for javascript",
   "contributors": [
     {
@@ -14,24 +14,16 @@
     }
   ],
   "license": "MPL-2.0",
+  "type": "module",
   "files": [
     "dist"
   ],
   "types": "./dist/RingBuffer.d.ts",
   "main": "./dist/RingBuffer.js",
-  "module": "./dist/RingBuffer.js",
-  "exports": {
-    ".": {
-      "import": "./dist/RingBuffer.js",
-      "require": "./dist/RingBuffer.js"
-    }
-  },
   "scripts": {
     "build": "tsc"
   },
-  "dependencies": {
-  },
   "devDependencies": {
-    "@types/node": "^17.0.38"
+    "typescript": "^5.0.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@thirdroom/ringbuffer",
-  "version": "0.1.0",
+  "name": "@joelrbrandt/ringbuffer",
+  "version": "0.3.0",
   "description": "thread safe data structures for javascript",
   "contributors": [
     {
@@ -16,7 +16,10 @@
   "license": "MPL-2.0",
   "type": "module",
   "files": [
-    "dist"
+    "dist",
+    "src",
+    "README.md",
+    "LICENSE"
   ],
   "types": "./dist/RingBuffer.d.ts",
   "main": "./dist/RingBuffer.js",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,9 @@
 {
   "compilerOptions": {
-    "target": "es2017",
+    "target": "es2020",
     "outDir": "dist",
     "moduleResolution": "node",
+    "lib": ["es2020"],
     "declaration": true,
     "inlineSourceMap": true,
     "esModuleInterop": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,7 @@
 # yarn lockfile v1
 
 
-"@types/node@^17.0.38":
-  version "17.0.38"
-  resolved "https://registry.npmjs.org/@types/node/-/node-17.0.38.tgz"
-  integrity sha512-5jY9RhV7c0Z4Jy09G+NIDTsCZ5G0L5n+Z+p+Y7t5VJHM30bgwzSjVtlcBxqAj+6L/swIlvtOSzr8rBk/aNyV2g==
+typescript@^5.0.4:
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.0.4.tgz#b217fd20119bd61a94d4011274e0ab369058da3b"
+  integrity sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==


### PR DESCRIPTION
The published version of this package includes an ESM-format module in the `/dist` folder.

However, because the `type` wasn't set to `"module"` in the package.json, I wasn't able to import this properly in node v18 and later.

This PR fixes up the package.json.

It also updates the `tsconfig.json` so that the package compiles with the most recent version of typescript, and adds typescript as a dev dependency (so that `npm install && npm run build` works).

I have temporarily published it to the package [`@joelrbrandt/ringbuffer`](https://www.npmjs.com/package/@joelrbrandt/ringbuffer), and I've confirmed that it works for me in both node v18 and webpack v5 (with appropriate configuration to load ESM modules).

Thank you for maintaining this package!

